### PR TITLE
Update screenshot functionality to support binary, dataURI, and file formats

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ await takeScreenshot({
 	height: 768, // Optional: window height (default: 768)
 	waitTime: 3, // Optional: seconds to wait for load (default: 3)
 	zoomLevel: 1, // Optional: page zoom level (default: 1)
+	returnFormat: 'file', // Optional: return format (binary, base64, file) (default: file)
 });
 
 // Responsive design testing
@@ -32,6 +33,7 @@ await takeScreenshot({
 	width: 375, // iPhone SE width
 	height: 667, // iPhone SE height
 	zoomLevel: 1,
+	returnFormat: 'file', // Optional: return format (binary, base64, file) (default: file)
 });
 
 // High-resolution capture
@@ -42,6 +44,7 @@ await takeScreenshot({
 	height: 1080, // Full HD height
 	waitTime: 5, // Wait longer for HD content
 	zoomLevel: 0.8, // Zoom out slightly
+	returnFormat: 'file', // Optional: return format (binary, base64, file) (default: file)
 });
 ```
 
@@ -60,14 +63,15 @@ npm install safari-screenshot
 
 ## Options
 
-| Option     | Type   | Default  | Description                                                                      |
-| ---------- | ------ | -------- | -------------------------------------------------------------------------------- |
-| url        | string | required | The URL to capture                                                               |
-| outputPath | string | auto     | Where to save the screenshot (default: ./screenshots/[hostname]-[timestamp].png) |
-| width      | number | 1024     | Window width in pixels                                                           |
-| height     | number | 768      | Window height in pixels                                                          |
-| waitTime   | number | 3        | Seconds to wait for page load                                                    |
-| zoomLevel  | number | 1        | Page zoom level (1 = 100%)                                                       |
+| Option       | Type   | Default  | Description                                                                      |
+| ------------ | ------ | -------- | -------------------------------------------------------------------------------- |
+| url          | string | required | The URL to capture                                                               |
+| outputPath   | string | auto     | Where to save the screenshot (default: ./screenshots/[hostname]-[timestamp].png) |
+| width        | number | 1024     | Window width in pixels                                                           |
+| height       | number | 768      | Window height in pixels                                                          |
+| waitTime     | number | 3        | Seconds to wait for page load                                                    |
+| zoomLevel    | number | 1        | Page zoom level (1 = 100%)                                                       |
+| returnFormat | string | file     | Return format of the screenshot (binary, base64, file)                           |
 
 ## Common Viewport Sizes
 
@@ -202,3 +206,41 @@ Expected responses:
    - Log progress to stderr
    - Return result JSON to stdout
    - Save screenshot to ./screenshots/
+
+## New Feature: Return Binary Data
+
+The `takeScreenshot` function now supports returning the screenshot as binary data or base64-encoded data URI instead of saving it to disk. This is useful for scenarios where you need to process the image directly in memory.
+
+### Usage Example
+
+```javascript
+import { takeScreenshot } from './screenshot.js';
+
+// Return binary data
+const resultBinary = await takeScreenshot({
+	url: 'https://www.apple.com',
+	returnFormat: 'binary',
+});
+
+if (resultBinary.binaryData) {
+	// Process the binary data
+	console.log('Screenshot binary data:', resultBinary.binaryData);
+}
+
+// Return base64-encoded data URI
+const resultBase64 = await takeScreenshot({
+	url: 'https://www.apple.com',
+	returnFormat: 'base64',
+});
+
+if (resultBase64.base64Data) {
+	// Process the base64-encoded data URI
+	console.log('Screenshot base64 data:', resultBase64.base64Data);
+}
+```
+
+### Options
+
+| Option       | Type   | Default  | Description                                                                      |
+| ------------ | ------ | -------- | -------------------------------------------------------------------------------- |
+| returnFormat | string | file     | Return format of the screenshot (binary, base64, file)                           |

--- a/src/index.ts
+++ b/src/index.ts
@@ -35,6 +35,7 @@ interface ScreenshotArgs {
 	height?: number;
 	waitTime?: number;
 	zoomLevel?: number;
+	returnFormat?: 'binary' | 'base64' | 'file';
 }
 
 // Type guard for screenshot arguments
@@ -77,6 +78,11 @@ const SCREENSHOT_TOOL: Tool = {
 				type: 'number',
 				description: 'Zoom level (1 = 100%, 0.5 = 50%, 2 = 200%)',
 				default: 1,
+			},
+			returnFormat: {
+				type: 'string',
+				description: 'Return format of the screenshot (binary, base64, file)',
+				default: 'file',
 			},
 		},
 		required: ['url'],
@@ -125,7 +131,30 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
 					height: args.height,
 					waitTime: args.waitTime,
 					zoomLevel: args.zoomLevel,
+					returnFormat: args.returnFormat,
 				});
+				if (args.returnFormat === 'binary' && result.binaryData) {
+					return {
+						content: [
+							{
+								type: 'image',
+								data: result.binaryData,
+								mimeType: 'image/png',
+							},
+						],
+						isError: false,
+					};
+				} else if (args.returnFormat === 'base64' && result.base64Data) {
+					return {
+						content: [
+							{
+								type: 'text',
+								text: result.base64Data,
+							},
+						],
+						isError: false,
+					};
+				}
 				return {
 					content: [
 						{


### PR DESCRIPTION
Supports returning the screenshot data as binary and dataURI directly so that agents can add it to their context without additional tooling.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/steviec/mcp-safari-screenshot/pull/1?shareId=b902e977-59dd-4946-9143-01b998606352).